### PR TITLE
Memory cleanup

### DIFF
--- a/doc/examples/all_sky_scan.py
+++ b/doc/examples/all_sky_scan.py
@@ -9,17 +9,18 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 # convert test statistic to a p-value for a given point
-pVal_func = lambda TS, dec: -np.log10(0.5 * (chi2(1).sf(TS) + chi2(1).cdf(-TS)))
+pVal_func = lambda TS, dec: -np.log10(0.5 * (chi2(len(llh.params)).sf(TS)
+                                             + chi2(len(llh.params)).cdf(-TS)))
 
 if __name__=="__main__":
 
     # init the llh class
-    llh = data.multi_init(4, 1000, 10000, ncpu=4)
+    llh = data.multi_init(4, 1000, 100000, ncpu=1, energy=True)
 
     print(llh)
 
     # iterator of all-sky scan with follow up scans of most interesting points
-    for i, (scan, hotspot) in enumerate(llh.all_sky_scan(nside=32,
+    for i, (scan, hotspot) in enumerate(llh.all_sky_scan(nside=16,
                                                          pVal=pVal_func,
                                                          decRange=np.radians([-90., 90.]))):
         if i > 0:
@@ -27,15 +28,32 @@ if __name__=="__main__":
             break
 
     # plot results
-    hp.mollview(scan["pVal"], min=0., cmap=plt.cm.afmhot)
+    hp.mollview(scan["pVal"], min=0., cmap=plt.cm.afmhot, rot=[-180., 0., 0.])
     if isinstance(llh, MultiPointSourceLLH):
         for llh in llh._sams.itervalues():
             hp.projscatter(np.degrees(llh.exp["ra"]),
                            np.degrees(np.arcsin(llh.exp["sinDec"])),
+                           rot=[-180., 0., 0.],
                            lonlat=True, marker="x", color=plt.gca()._get_lines.color_cycle.next())
     else:
         hp.projscatter(np.degrees(llh.exp["ra"]),
                        np.degrees(np.arcsin(llh.exp["sinDec"])),
+                       rot=[-180., 0., 0.],
                        lonlat=True, marker="x", color="red")
+
     plt.show()
+
+    for key in llh.params:
+        eps = 0.1
+        q = scan[key]
+        if not key == "nsources":
+            q = np.ma.masked_array(q)
+            q.mask = ~(scan["nsources"]
+                       > np.percentile(scan["nsources"][scan["nsources"] > 0],
+                                       eps))
+        hp.mollview(q, unit=key, cmap=plt.cm.cubehelix,
+                    rot=[-180., 0., 0.],
+                    min=min(0., np.percentile(scan[key], eps)),
+                    max=np.percentile(scan[key], 100. - eps))
+        plt.show()
 

--- a/doc/examples/all_sky_scan.py
+++ b/doc/examples/all_sky_scan.py
@@ -51,7 +51,7 @@ if __name__=="__main__":
             q.mask = ~(scan["nsources"]
                        > np.percentile(scan["nsources"][scan["nsources"] > 0],
                                        eps))
-        hp.mollview(q, unit=key, cmap=plt.cm.cubehelix,
+        hp.mollview(q, unit=key, cmap=plt.cm.cubehelix_r,
                     rot=[-180., 0., 0.],
                     min=min(0., np.percentile(scan[key], eps)),
                     max=np.percentile(scan[key], 100. - eps))

--- a/doc/examples/data.py
+++ b/doc/examples/data.py
@@ -18,25 +18,29 @@ from skylab.ps_model import ClassicLLH, EnergyLLH
 
 log_mean = np.log(np.radians(2.5))
 log_sig = 0.5
-logE_mean = np.log(1.)
-logE_sig = 1.
+logE_res = 0.3
 
 np.random.seed(1)
 
 def exp(N=100):
     r"""Create uniformly distributed data on sphere. """
+    g = 3.7
+
     arr = np.empty((N, ), dtype=[("ra", np.float), ("sinDec", np.float),
                                  ("sigma", np.float), ("logE", np.float)])
 
     arr["ra"] = np.random.uniform(0., 2.*np.pi, N)
     arr["sinDec"] = np.random.uniform(-1., 1., N)
     arr["sigma"] = np.random.lognormal(mean=log_mean, sigma=log_sig, size=N)
-    arr["logE"] = logE_mean + logE_sig * np.random.normal(size=N)
+    x = np.random.uniform(0., 1., size=N)
+    arr["logE"] = np.log10(1. - x) / (1. - g) + logE_res * np.random.normal(size=N)
 
     return arr
 
 def MC(N=1000):
     r"""Create uniformly distributed MC data on sphere. """
+    g = 2.
+
     arr = np.empty((N, ), dtype=[("ra", np.float), ("sinDec", np.float),
                                  ("sigma", np.float), ("logE", np.float),
                                  ("trueRa", np.float), ("trueDec", np.float),
@@ -46,7 +50,8 @@ def MC(N=1000):
 
     arr["trueRa"] = np.random.uniform(0., 2.*np.pi, N)
     arr["trueDec"] = np.arcsin(np.random.uniform(-1., 1., N))
-    arr["trueE"] = np.random.lognormal(mean=logE_mean, sigma=logE_sig, size=N)
+    x = np.random.uniform(0., 1., N)
+    arr["trueE"] = (1. - x)**(1. / (1. - g))
     arr["ow"] = arr["trueE"]
     arr["ow"] /= arr["ow"].sum()
 
@@ -54,7 +59,7 @@ def MC(N=1000):
     arr["sigma"] = np.random.lognormal(mean=log_mean, sigma=log_sig, size=N)
     arr["ra"] = arr["trueRa"] + np.cos(eta) * arr["sigma"] / np.cos(arr["trueDec"])
     arr["sinDec"] = np.sin(arr["trueDec"] + np.sin(eta) * arr["sigma"])
-    arr["logE"] = np.log10(arr["trueE"]) + np.random.normal(size=len(arr)) #/ 4
+    arr["logE"] = np.log10(arr["trueE"]) + logE_res * np.random.normal(size=len(arr))
 
     return arr
 

--- a/doc/examples/data.py
+++ b/doc/examples/data.py
@@ -42,18 +42,19 @@ def MC(N=1000):
                                  ("trueRa", np.float), ("trueDec", np.float),
                                  ("trueE", np.float), ("ow", np.float)])
 
-    arr["ra"] = np.random.uniform(0., 2.*np.pi, N)
-    arr["sinDec"] = np.random.uniform(-1., 1., N)
-    arr["sigma"] = np.random.lognormal(mean=log_mean, sigma=log_sig, size=N)
-    arr["logE"] = logE_mean + logE_sig * np.random.normal(size=N)
+    # true information
 
-    eta = np.random.uniform(0., 2.*np.pi, N)
-    arr["trueRa"] = arr["ra"] + np.cos(eta) * arr["sigma"] / np.sqrt(1. - arr["sinDec"]**2)
-    arr["trueDec"] = np.arcsin(arr["sinDec"]) + np.sin(eta) * arr["sigma"]
-    arr["trueRa"] = np.arccos(np.cos(arr["trueRa"]))
-    arr["trueDec"] = np.arcsin(np.sin(arr["trueDec"]))
+    arr["trueRa"] = np.random.uniform(0., 2.*np.pi, N)
+    arr["trueDec"] = np.arcsin(np.random.uniform(-1., 1., N))
     arr["trueE"] = np.random.lognormal(mean=logE_mean, sigma=logE_sig, size=N)
-    arr["ow"] = 1./N
+    arr["ow"] = arr["trueE"]
+    arr["ow"] /= arr["ow"].sum()
+
+    eta = np.random.uniform(0., 2.*np.pi, len(arr))
+    arr["sigma"] = np.random.lognormal(mean=log_mean, sigma=log_sig, size=N)
+    arr["ra"] = arr["trueRa"] + np.cos(eta) * arr["sigma"] / np.cos(arr["trueDec"])
+    arr["sinDec"] = np.sin(arr["trueDec"] + np.sin(eta) * arr["sigma"])
+    arr["logE"] = np.log10(arr["trueE"]) + np.random.normal(size=len(arr)) #/ 4
 
     return arr
 
@@ -62,34 +63,36 @@ def init(Nexp, NMC, energy=False, **kwargs):
     arr_mc = MC(NMC)
 
     if energy:
-        llh_model = EnergyLLH(sinDec_bins=max(2, Nexp // 10),
+        llh_model = EnergyLLH(sinDec_bins=max(3, Nexp // 200),
                               sinDec_range=[-1., 1.],
-                              twodim_bins=max(3, Nexp // 100),
+                              twodim_bins=max(3, Nexp // 200),
                               twodim_range=[[0.9 * min(arr_exp["logE"].min(),
                                                        arr_mc["logE"].min()),
                                              1.1 * max(arr_exp["logE"].max(),
                                                        arr_exp["logE"].max())],
                                              [-1., 1.]])
     else:
-        llh_model = ClassicLLH(sinDec_bins=max(2, Nexp // 10),
+        llh_model = ClassicLLH(sinDec_bins=max(3, Nexp // 200),
                                sinDec_range=[-1., 1.])
 
     llh = PointSourceLLH(arr_exp, arr_mc, 365., llh_model=llh_model,
                          mode="all", hemispheres=dict(Full=[-np.inf, np.inf]),
-                         rho_nsource_bounds=(-0.8, 0.8),
+                         rho_nsource_bounds=(-0.8, 0.8) if not energy else (0., 0.8),
                          seed=np.random.randint(2**32),
                          **kwargs)
 
     return llh
 
 def multi_init(n, Nexp, NMC, **kwargs):
+    energy = kwargs.pop("energy", False)
+
     llh = MultiPointSourceLLH(hemispheres=dict(Full=[-np.inf, np.inf]),
-                              rho_nsource_bounds=(-0.8, 0.8),
+                              rho_nsource_bounds=(-0.8, 0.8) if not energy else (0., 0.8),
                               seed=np.random.randint(2**32),
                               **kwargs)
 
     for i in xrange(n):
-        llh.add_sample(str(i), init(Nexp, NMC, **kwargs))
+        llh.add_sample(str(i), init(Nexp, NMC, energy=energy))
 
     return llh
 

--- a/doc/examples/data.py
+++ b/doc/examples/data.py
@@ -82,7 +82,9 @@ def init(Nexp, NMC, energy=False, **kwargs):
 
     llh = PointSourceLLH(arr_exp, arr_mc, 365., llh_model=llh_model,
                          mode="all", hemispheres=dict(Full=[-np.inf, np.inf]),
-                         rho_nsource_bounds=(-0.8, 0.8) if not energy else (0., 0.8),
+                         nsource=Nexp / 100.,
+                         nsource_bounds=(-Nexp / 2., Nexp / 2.)
+                                        if not energy else (0., Nexp / 2.),
                          seed=np.random.randint(2**32),
                          **kwargs)
 
@@ -92,7 +94,9 @@ def multi_init(n, Nexp, NMC, **kwargs):
     energy = kwargs.pop("energy", False)
 
     llh = MultiPointSourceLLH(hemispheres=dict(Full=[-np.inf, np.inf]),
-                              rho_nsource_bounds=(-0.8, 0.8) if not energy else (0., 0.8),
+                              nsource=Nexp / 100.,
+                              nsource_bounds=(-Nexp / 2., Nexp / 2.)
+                                             if not energy else (0., Nexp / 2.),
                               seed=np.random.randint(2**32),
                               **kwargs)
 

--- a/doc/examples/weighted_sensitivity.py
+++ b/doc/examples/weighted_sensitivity.py
@@ -1,6 +1,6 @@
 # -*-coding:utf8-*-
 
-from data import init
+import data
 
 from scipy.stats import chi2
 import healpy as hp
@@ -8,11 +8,18 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 from skylab.ps_injector import PointSourceInjector
+from skylab.psLLH import MultiPointSourceLLH
 
 if __name__=="__main__":
 
     # init likelihood class
-    llh = init(1000, 1000000, ncpu=4, energy=False)
+    llh = data.multi_init(4, 1000, 100000, ncpu=1, energy=True)
+
+    N_MC = 1000
+    if isinstance(llh, MultiPointSourceLLH):
+        mc = dict([(key, data.MC(N_MC)) for key in llh._enum.iterkeys()])
+    else:
+        mc = data.MC(N_MC)
 
     print(llh)
 
@@ -21,8 +28,8 @@ if __name__=="__main__":
 
     # start calculation for dec = 0
     result = llh.weighted_sensitivity(0., [0.5, 2.87e-7], [0.9, 0.5],
-                                      inj,
-                                      n_bckg=10000,
+                                      inj, mc,
+                                      n_bckg=1000,
                                       n_iter=1000,
                                       eps=5.e-2)
 

--- a/skylab/psLLH.py
+++ b/skylab/psLLH.py
@@ -1458,7 +1458,7 @@ class PointSourceLLH(object):
                              " same length!")
 
         # setup source injector
-        inj.fill(src_dec, mc)
+        inj.fill(src_dec, mc, self.livetime)
 
         print("Estimate Sensitivity for declination {0:5.1f} deg".format(
                 np.degrees(src_dec)))
@@ -1816,6 +1816,16 @@ class MultiPointSourceLLH(PointSourceLLH):
         self._gamma_binmids = (value[1:] + value[:-1]) / 2.
 
         return
+
+    @property
+    def livetime(self):
+        return dict([(enum, sam.livetime)
+                     for enum, sam in self._sams.iteritems()])
+
+    @livetime.setter
+    def livetime(self, val):
+        raise NotImplementedError("Livetime is defined in add sub-classes "
+                                  "PointSourceLLH")
 
     @property
     def params(self):

--- a/skylab/psLLH.py
+++ b/skylab/psLLH.py
@@ -1714,7 +1714,6 @@ class MultiPointSourceLLH(PointSourceLLH):
         self._sams = dict()
         self._nuhist = dict()
         self._nuspline = dict()
-        self.mc = dict()
 
         return
 
@@ -1906,9 +1905,6 @@ class MultiPointSourceLLH(PointSourceLLH):
 
         self._enum[enum] = name
         self._sams[enum] = obj
-
-        # add mc info for injection
-        self.mc[enum] = obj.mc
 
         # create histogram of signal expectation for this sample
         x = np.sin(obj.mc["trueDec"])

--- a/skylab/psLLH.py
+++ b/skylab/psLLH.py
@@ -1249,14 +1249,13 @@ class PointSourceLLH(object):
 
         return
 
-    def weighted_sensitivity(self, src_dec, alpha, beta, inj, **kwargs):
+    def weighted_sensitivity(self, src_dec, alpha, beta, inj, mc, **kwargs):
         """Calculate the point source sensitivity for a given source
         hypothesis using weights.
 
         All trials calculated are used at each step and weighted using the
-        Poissonian probability.
-
-        Credits for this idea goes to Asen Christov of IceCube.
+        Poissonian probability. Credits for this idea goes to Asen Christov of
+        IceCube in Geneva.
 
         Parameters
         ----------
@@ -1268,6 +1267,10 @@ class PointSourceLLH(object):
             Error of second kind
         inj : skylab.BaseInjector instance
             Injection module
+        mc : numpy-recarray
+            Monte Carlo to use for injection. Needs all fields that
+            is stored in experimental data, plus true information that the
+            injector uses: trueRa, trueDec, trueE, ow
 
         Returns
         -------
@@ -1455,7 +1458,7 @@ class PointSourceLLH(object):
                              " same length!")
 
         # setup source injector
-        inj.fill(src_dec, self.mc)
+        inj.fill(src_dec, mc)
 
         print("Estimate Sensitivity for declination {0:5.1f} deg".format(
                 np.degrees(src_dec)))

--- a/skylab/psLLH.py
+++ b/skylab/psLLH.py
@@ -708,7 +708,7 @@ class PointSourceLLH(object):
                         for ra_i, dec_i, xmin_i in zip(ra[mask], dec[mask],
                                                        xmins[mask])]
                 pool = multiprocessing.Pool(self.ncpu)
-                result = pool.map(fs, args)#, len(args) // self.ncpu + 1)
+                result = pool.map(fs, args)
 
                 pool.close()
                 pool.join()
@@ -958,7 +958,7 @@ class PointSourceLLH(object):
 
             pool = multiprocessing.Pool(self.ncpu)
 
-            result = pool.map(fs, args, len(args) // self.ncpu + 1)
+            result = pool.map(fs, args)
 
             pool.close()
             pool.join()
@@ -1129,8 +1129,10 @@ class PointSourceLLH(object):
             # null hypothesis is part of minimisation, fit should be negative
             if abs(fmin) > kwargs["pgtol"]:
                 # SPAM only if the distance is large
-                logger.error("Fitter returned positive value "
-                             "force to be zero.")
+                logger.error("Fitter returned positive value, "
+                             "force to be zero at null-hypothesis. "
+                             "Minimum found {0} with fmin {1}".format(
+                                 xmin, fmin))
             fmin = 0
             xmin[0] = 0.
 

--- a/skylab/psLLH.py
+++ b/skylab/psLLH.py
@@ -537,7 +537,7 @@ class PointSourceLLH(object):
         # set likelihood module to variable and fill it with data
         self._llh_model = val
 
-        self._llh_model(self.exp, mc)
+        self._llh_model(self.exp, mc, self.livetime)
 
         return
 
@@ -1977,9 +1977,6 @@ class MultiPointSourceLLH(PointSourceLLH):
         for i, (enum, sam) in enumerate(self._sams.iteritems()):
             w[i], dw = sam.llh_model.effA(src_dec, **fit_pars)
 
-            # adjust livetime
-            w[i] *= sam.livetime
-
             if dw is None:
                 continue
 
@@ -1987,7 +1984,7 @@ class MultiPointSourceLLH(PointSourceLLH):
                 if par not in dw:
                     continue
 
-                grad_w[i, j] = dw[par] * sam.livetime
+                grad_w[i, j] = dw[par]
 
         # normalize weights to one
         grad_w /= w.sum()

--- a/skylab/ps_injector.py
+++ b/skylab/ps_injector.py
@@ -353,7 +353,7 @@ class PointSourceInjector(Injector):
 
         return
 
-    def fill(self, src_dec, mc):
+    def fill(self, src_dec, mc, livetime):
         r"""Fill the Injector with MonteCarlo events selecting events around
         the source position(s).
 
@@ -361,11 +361,15 @@ class PointSourceInjector(Injector):
         -----------
         src_dec : float, array-like
             Source location(s)
-
         mc : recarray, dict of recarrays with sample enum as key (MultiPointSourceLLH)
             Monte Carlo events
+        livetime : float, dict of floats
+            Livetime per sample
 
         """
+
+        if isinstance(mc, dict) ^ isinstance(livetime, dict):
+            raise ValueError("mc and livetime not compatible")
 
         self.src_dec = src_dec
 
@@ -375,6 +379,7 @@ class PointSourceInjector(Injector):
 
         if not isinstance(mc, dict):
             mc = {-1: mc}
+            livetime = {-1: livetime}
 
         for key, mc_i in mc.iteritems():
             # get MC event's in the selected energy and sinDec range
@@ -395,7 +400,7 @@ class PointSourceInjector(Injector):
             mc_arr = np.empty(N, dtype=self.mc_arr.dtype)
             mc_arr["idx"] = np.arange(N)
             mc_arr["enum"] = key * np.ones(N)
-            mc_arr["ow"] = self.mc[key]["ow"]
+            mc_arr["ow"] = self.mc[key]["ow"] * livetime[key] * 86400.
             mc_arr["trueE"] = self.mc[key]["trueE"]
 
             self.mc_arr = np.append(self.mc_arr, mc_arr)

--- a/skylab/ps_model.py
+++ b/skylab/ps_model.py
@@ -297,8 +297,6 @@ class WeightLLH(ClassicLLH):
 
     """
 
-    _mc = None
-
     _precision = _precision
 
     _g1 = _par_val
@@ -408,6 +406,9 @@ class WeightLLH(ClassicLLH):
             self._ratio_spline(**dict([(p_i, self._around(t_i))
                                        for p_i, t_i in zip(pars, tup)]))
 
+        # all calculations done, delete monte carlo information
+        del self._mc
+
         return
 
     def __str__(self):
@@ -504,13 +505,6 @@ class WeightLLH(ClassicLLH):
             Spline for parameter values *params*
 
         """
-
-        # use previous calculations if existing
-        if self._w_spline_dict.has_key(tuple(params.items())):
-            return self._w_spline_dict[tuple(params.items())]
-
-        print("Calculate splines for", "\t".join(["{0:10s} - {1:.2f}".format(key, val) for key, val in params.iteritems()]),
-              "Number of splines:", len(self._w_spline_dict))
 
         mcvars = [self._mc[p] if not p == "sinDec"
                               else np.sin(self._mc["trueDec"])
@@ -617,11 +611,11 @@ class WeightLLH(ClassicLLH):
             g0 = self._around(g1 - dg)
             g2 = self._around(g1 + dg)
 
-            S0 = self._spline_eval(self._ratio_spline(gamma=g0), ev)
-            S1 = self._spline_eval(self._ratio_spline(gamma=g1), ev)
-            S2 = self._spline_eval(self._ratio_spline(gamma=g2), ev)
+            S0 = self._spline_eval(self._w_spline_dict[(("gamma", g0), )], ev)
+            S1 = self._spline_eval(self._w_spline_dict[(("gamma", g1), )], ev)
+            S2 = self._spline_eval(self._w_spline_dict[(("gamma", g2), )], ev)
 
-            a = (S0 - 2.*S1 + S2) / (2. * dg**2)
+            a = (S0 - 2. * S1 + S2) / (2. * dg**2)
             b = (S2 - S0) / (2. * dg)
 
             # cache values

--- a/skylab/ps_model.py
+++ b/skylab/ps_model.py
@@ -301,6 +301,10 @@ class ClassicLLH(NullModel):
 
         """
 
+        if (np.sin(dec) < self.sinDec_bins[0]
+                or np.sin(dec) > self.sinDec_bins[-1]):
+            return 0., None
+
         return self._spl_effA(dec), None
 
     def reset(self):
@@ -765,6 +769,10 @@ class PowerLawLLH(WeightLLH):
             Gradient at given point(s).
 
         """
+
+        if (np.sin(dec) < self.sinDec_bins[0]
+                or np.sin(dec) > self.sinDec_bins[-1]):
+            return 0., None
 
         gamma = params["gamma"]
 


### PR DESCRIPTION
Monte Carlo arrays are stored during all execution time, using a lot of memory only for calculating histograms when needed and doing injection. Create histograms at execution time making the storage of MC redundant. Removing the MC saves a lot of memory, especially in multiprocessing where these arrays would be copied.
Weights for the injection now need to be calculated in the ps_model as well. This is wanted (e.g. stacking needs this as well) and allows the same functionality as the weight calculation (different weighting, etc.).
